### PR TITLE
Add note error state

### DIFF
--- a/components.json
+++ b/components.json
@@ -610,6 +610,11 @@
           "type": "note_titled",
           "title": "And all that is now",
           "text": "Service fees are deducted from your earnings after each rental (25.0%). The price paid by the driver includes additional fees and discounts for long rentals. <a href=\"https://www.google.com/\">Learn more about pricing.</a>"
+        },
+        {
+          "type": "note",
+          "text": "Only the driver can cancel this rental.",
+          "state": "error"
         }
       ]
     },

--- a/components.json
+++ b/components.json
@@ -614,7 +614,7 @@
         {
           "type": "note",
           "text": "Only the driver can cancel this rental.",
-          "state": "error"
+          "status": "error"
         }
       ]
     },


### PR DESCRIPTION
## Why 
Add a state property to the note component returning a string.
Currently with a default `info` or with `error` to display the note in red.

>**Note**
>Passing `info`, nil, or nothing display the default note with info semantic colours.


- [Android PR](https://github.com/drivy/drivy-android/pull/4298)
- [iOS PR](https://github.com/drivy/drivy-ios/pull/2333)

Android|iOS
---|---
<img src="https://user-images.githubusercontent.com/24393058/215098958-382fced1-918e-46d3-bf6d-f238988df9c9.png" width="200">|<img src="https://user-images.githubusercontent.com/49998863/215034665-58b91cf3-8e20-4f4a-aa8f-526dba2f70ee.png" width="300">

